### PR TITLE
Support multiple test results from parallel UI test runs

### DIFF
--- a/ProcessTestSummaries/main.swift
+++ b/ProcessTestSummaries/main.swift
@@ -488,7 +488,11 @@ func generateJUnitReport(testSummariesPlistJson: JSON, logsTestPath: String, jUn
 /// - Parameter path: String representing target directory
 /// - Parameter subDirectory: String representing the subdirectory you wish to append to path
 /// - Returns: The new subdirectory path under the original path
-func appendSubdirectoryToPath(_ path: String, subDirectory: String) -> String {
+func appendSubdirectoryToPath(_ path: String?, subDirectory: String) -> String? {
+    guard let path = path else {
+        return nil
+    }
+
     if subDirectory.isEmpty {
         return path
     }
@@ -572,7 +576,7 @@ if let screenshotsPathOptionValue = screenshotsPathOptionValue {
     var subDirectory = testSummariesPlistJsons.count > 1 ? "\(fileCount)" : ""
 
     testSummariesPlistJsons.forEach { testSummariesPlistJson in
-    saveLastScreenshots(testSummariesPlistJson: testSummariesPlistJson, logsTestPath: logsTestPath, lastScreenshotsPath: appendSubdirectoryToPath(screenshotsPathOptionValue, subDirectory: subDirectory), screenshotsCount: screenshotsCount, excludeIdenticalScreenshots: excludeIdenticalScreenshots)
+    saveLastScreenshots(testSummariesPlistJson: testSummariesPlistJson, logsTestPath: logsTestPath, lastScreenshotsPath: appendSubdirectoryToPath(screenshotsPathOptionValue, subDirectory: subDirectory)!, screenshotsCount: screenshotsCount, excludeIdenticalScreenshots: excludeIdenticalScreenshots)
         fileCount += 1
         subDirectory = "\(fileCount)"
     }
@@ -590,7 +594,7 @@ if let jUnitReportPathOptionValue = jUnitReportPathOptionValue {
     var subDirectory = testSummariesPlistJsons.count > 1 ? "\(fileCount)" : ""
 
     testSummariesPlistJsons.forEach { testSummariesPlistJson in
-        generateJUnitReport(testSummariesPlistJson: testSummariesPlistJson, logsTestPath: logsTestPath, jUnitRepPath: appendSubdirectoryToPath(path, subDirectory: subDirectory) + fileName, noCrashLogs: noCrashLogs, lastScreenshotsPath: screenshotsPathOptionValue, screenshotsCount: screenshotsCount, buildUrl: buildUrlOptionValue, workspacePath: workspacePathOptionValue ?? "")
+        generateJUnitReport(testSummariesPlistJson: testSummariesPlistJson, logsTestPath: logsTestPath, jUnitRepPath: appendSubdirectoryToPath(path, subDirectory: subDirectory)! + fileName, noCrashLogs: noCrashLogs, lastScreenshotsPath: appendSubdirectoryToPath(screenshotsPathOptionValue, subDirectory: subDirectory), screenshotsCount: screenshotsCount, buildUrl: buildUrlOptionValue, workspacePath: workspacePathOptionValue ?? "")
         fileCount += 1
         subDirectory = "\(fileCount)"
     }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This tool is an OS X console application which processes the TestSummaries plist
 - the last screenshots are saved for each test in a separate folder and in the order they were created in test
 - the consecutive identical screenshots can be excluded, to save just the relevant screenshots
 - the generated files can be easily added as artifacts in Jenkins for the tests job
+- supports Xcode 9's parallel testing. Multiple test results are placed in numbered subdirectories and reports are differentiated by device name & iOS version
 
 ## Usage e.g:
 xcodebuild -derivedDataPath $DERIVED_DATA_PATH test


### PR DESCRIPTION
# What this is
With Xcode 9, you can now run parallel tests. This produces multiple test result plist bundles. ProcessTestSummaries would always return the first .plist result, making it unable to process multiple results without moving files around yourself between runs.

What this does is iterates over all test results and creates subdirectories for each plist found. Each subdirectory contains the process results of each test result.

I made the following changes in order to do this:

## Looped the JUNIT conversion processes
Most of the work was already done, you just needed to add a few for loops here and there to perform the same work for every .plist file found. Additionally I modified some existing methods to return arrays rather than one object.

## Created result subdirectories in the case of multiple plist files.
If there are multiple .plist files in the supplied `jUnitReportPath`, the results were dumped into subdirectories for the `logsTestPath` and `screenshotsPath`. If there was only one .plist file, no subdirectories are created.

Subdirectory names are simply "1", "2", etc... to make it easy to iterate over if you need to on Jenkins.

## Gave the `testsuites` node a name property
Multiple JUNIT bundles need unique identifiers on Jenkins or else you get conflicting results. I used the device model + device OS to give the top-level "testsuites" node a name attribute so Jenkins can keep these reports separated.
